### PR TITLE
fix: pass features to cargo lambda flags

### DIFF
--- a/lib/htsget-lambda-construct.ts
+++ b/lib/htsget-lambda-construct.ts
@@ -299,7 +299,7 @@ export class HtsgetLambdaConstruct extends Construct {
           CARGO_PROFILE_RELEASE_LTO: "true",
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1",
         },
-        cargoLambdaFlags: ["--features", features.join(",")],
+        cargoLambdaFlags: features,
       },
       memorySize: 128,
       timeout: Duration.seconds(28),

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
     "run": "cdk deploy",
     "watch": "tsc -w"
   },
-  "version": "0.7.0"
+  "version": "0.7.1"
 }


### PR DESCRIPTION
### Changes
* Correctly passes features to the `cargoLambdaFlags`.