### PR TITLE
fix: git force

### DIFF
--- a/lib/htsget-lambda.ts
+++ b/lib/htsget-lambda.ts
@@ -70,7 +70,7 @@ export class HtsgetLambda extends Construct {
 
     const manifestPath = getManifestPath({
       gitRemote: "https://github.com/umccr/htsget-rs",
-      gitForceClone: true,
+      gitForceClone: props.gitForceClone,
       gitReference: props.gitReference,
     });
     const repoDir = path.dirname(manifestPath);

--- a/package.json
+++ b/package.json
@@ -36,5 +36,5 @@
     "watch": "tsc -w",
     "typedoc": "typedoc"
   },
-  "version": "0.8.0"
+  "version": "0.8.1"
 }


### PR DESCRIPTION
### Changes
* Adds missing `gitForceClone` option to the manifest path logic