### PR TITLE
fix: git force

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,5 @@
     "watch": "tsc -w",
     "typedoc": "typedoc"
   },
-  "version": "0.8.1"
+  "version": "0.8.2"
 }


### PR DESCRIPTION
### Changes
* Fixes issue which was causing manifest path to not get set if not using `gitForceClone`.