### PR TITLE
fix: create path after checking existence

### DIFF
--- a/lib/htsget-lambda.ts
+++ b/lib/htsget-lambda.ts
@@ -79,8 +79,6 @@ export class HtsgetLambda extends Construct {
 
     const localPath = join(tmpdir(), latestCommit);
 
-    mkdirSync(localPath, { recursive: true });
-
     const args = ["clone"];
     if (gitReference === "HEAD") {
       args.push("--depth", "1");
@@ -88,6 +86,8 @@ export class HtsgetLambda extends Construct {
 
     args.push(gitRemote, localPath);
     if (!existsSync(localPath)) {
+      mkdirSync(localPath, { recursive: true });
+
       exec("git", args);
 
       if (gitReference !== "HEAD") {

--- a/package.json
+++ b/package.json
@@ -36,5 +36,5 @@
     "watch": "tsc -w",
     "typedoc": "typedoc"
   },
-  "version": "0.8.6"
+  "version": "0.8.7"
 }


### PR DESCRIPTION
### Changes
* The check for the existing path needs to actually create it if it's missing.