### PR TITLE
ci: trusted publish

### DIFF
--- a/.github/workflows/release-aws.yaml
+++ b/.github/workflows/release-aws.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released]
 
+permissions:
+  id-token: write
+
 jobs:
   release:
     if: ${{ startsWith(github.event.release.tag_name, 'htsget-lambda') }}
@@ -22,5 +25,3 @@ jobs:
         working-directory: aws
       - run: pnpm publish --access public --no-git-checks
         working-directory: aws
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.HTSGET_RS_DEPLOY_PUBLISH_TOKEN }}

--- a/.github/workflows/release-cloudflare.yaml
+++ b/.github/workflows/release-cloudflare.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released]
 
+permissions:
+  id-token: write
+
 jobs:
   release:
     if: ${{ startsWith(github.event.release.tag_name, 'htsget-workers') }}
@@ -22,5 +25,3 @@ jobs:
         working-directory: cloudflare
       - run: pnpm publish --access public --no-git-checks
         working-directory: cloudflare
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.HTSGET_RS_DEPLOY_PUBLISH_TOKEN }}

--- a/aws-vpc-lattice/package.json
+++ b/aws-vpc-lattice/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "htsget-lambda",
+  "name": "@umccr/htsget-vpc-lattice",
   "version": "0.9.4",
   "dependencies": {
     "cargo-lambda-cdk": "0.0.33",

--- a/aws/package.json
+++ b/aws/package.json
@@ -11,7 +11,7 @@
     "typedoc-plugin-markdown": "^4.8.1",
     "typescript": "5.9.2"
   },
-  "name": "htsget-lambda",
+  "name": "@umccr/htsget-lambda",
   "peerDependencies": {
     "aws-cdk-lib": "^2.112.0"
   },

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -15,7 +15,7 @@
     "typescript": "5.8.3",
     "wrangler": "^4.28.1"
   },
-  "name": "htsget-workers",
+  "name": "@umccr/htsget-workers",
   "scripts": {
     "build": "wrangler types && tsc",
     "cdk": "cdk",


### PR DESCRIPTION
### Changes
* Use the npm trusted publishing id token instead of long-lived secret.
* Scope package to umccr. 