### PR TITLE
fix: re-publish to avoid broken workspace link

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,14 +5,12 @@
     "aws": {
       "release-type": "node",
       "component": "htsget-lambda",
-      "package-name": "@umccr/htsget-lambda",
-      "initial-version": "0.1.0"
+      "package-name": "@umccr/htsget-lambda"
     },
     "aws-vpc-lattice": {
       "release-type": "node",
       "component": "htsget-vpc-lattice",
-      "package-name": "@umccr/htsget-vpc-lattice",
-      "initial-version": "0.1.0"
+      "package-name": "@umccr/htsget-vpc-lattice"
     }
   },
   "plugins": ["node-workspace"]


### PR DESCRIPTION
The manual publish used npm which doesn't understand the `workspace:` field, so re-publish with the now set-up trusted publish.

### Changes
* Re-publish using release-please.